### PR TITLE
Add ability to host on heroku (and use review apps)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@
 _site/
 .sass-cache/
 .jekyll-metadata
-Gemfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source "https://rubygems.org"
-ruby RUBY_VERSION
+ruby '~> 2.2.0'
 
 # Hello! This is where you manage which Jekyll version is used to run.
 # When you want to use a different version, change it below, save the
@@ -26,3 +26,7 @@ end
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
+# Heroku deploy
+gem 'puma'
+gem 'rack-jekyll'
+gem 'rake'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,67 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.5.1)
+      public_suffix (~> 2.0, >= 2.0.2)
+    colorator (1.1.0)
+    ffi (1.9.18)
+    forwardable-extended (2.6.0)
+    jekyll (3.4.3)
+      addressable (~> 2.4)
+      colorator (~> 1.0)
+      jekyll-sass-converter (~> 1.0)
+      jekyll-watch (~> 1.1)
+      kramdown (~> 1.3)
+      liquid (~> 3.0)
+      mercenary (~> 0.3.3)
+      pathutil (~> 0.9)
+      rouge (~> 1.7)
+      safe_yaml (~> 1.0)
+    jekyll-feed (0.9.2)
+      jekyll (~> 3.3)
+    jekyll-sass-converter (1.5.0)
+      sass (~> 3.4)
+    jekyll-watch (1.5.0)
+      listen (~> 3.0, < 3.1)
+    kramdown (1.13.2)
+    liquid (3.0.6)
+    listen (3.0.8)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
+    mercenary (0.3.6)
+    minima (2.1.1)
+      jekyll (~> 3.3)
+    pathutil (0.14.0)
+      forwardable-extended (~> 2.6)
+    public_suffix (2.0.5)
+    puma (3.9.1)
+    rack (1.6.8)
+    rack-jekyll (0.5.0)
+      jekyll (>= 1.3)
+      listen (>= 1.3)
+      rack (~> 1.5)
+    rake (12.0.0)
+    rb-fsevent (0.9.8)
+    rb-inotify (0.9.10)
+      ffi (>= 0.5.0, < 2)
+    rouge (1.11.1)
+    safe_yaml (1.0.4)
+    sass (3.4.24)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  jekyll (= 3.4.3)
+  jekyll-feed (~> 0.6)
+  minima (~> 2.0)
+  puma
+  rack-jekyll
+  rake
+  tzinfo-data
+
+RUBY VERSION
+   ruby 2.2.2p95
+
+BUNDLED WITH
+   1.13.6

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: bundle exec puma -t 8:32 -w 3 -p $PORT

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,5 @@
+namespace :assets do
+  task :precompile do
+    puts `bundle exec jekyll build`
+  end
+end

--- a/_config.yml
+++ b/_config.yml
@@ -28,5 +28,9 @@ markdown: kramdown
 gems:
   - jekyll-feed
 exclude:
+  - config.ru
   - Gemfile
   - Gemfile.lock
+  - Procfile
+  - Rakefile
+  - vendor

--- a/app.json
+++ b/app.json
@@ -1,0 +1,8 @@
+{
+  "name": "100days",
+  "description": "This app is the mini-site for EDGI's First 100 Days report.",
+  "website": "https://100days.envirodatagov.org/",
+  "repository": "http://github.com/edgi-govdata-archiving/100days/",
+  "logo": "https://pbs.twimg.com/profile_images/838966379348905985/2GSiia1I.jpg",
+  "image": "heroku/ruby"
+}

--- a/config.ru
+++ b/config.ru
@@ -1,0 +1,2 @@
+require 'rack/jekyll'
+run Rack::Jekyll.new


### PR DESCRIPTION
This is an demo of a potential resolution to #29.

This would allow us to set things up like so:
- each pending change request (aka a "pull request" in github-speak) gets it's own "review app" created and linked automatically in issues like this
  - Example: https://github.com/patcon/100days/pull/1 (please take a look, as this is the really convenient part!)
- merges to master would auto-deploy to https://edgi-100days.herokuapp.com
  * custom domain and SSL setup still required, but supported by Heroku.

This would allow anyone to review pending pull requests, and +1 them after review. If desired, non-code contributors could approve in GitHub comments after visual inspection. (If folks we oppposed to using GitHub, we could do that on Slack instead.)