### PR TITLE
Modularize Header

### DIFF
--- a/_includes/back-to-article-part1.html
+++ b/_includes/back-to-article-part1.html
@@ -1,0 +1,8 @@
+<div class="back-to-article dib mh3">
+  <div class="dib">
+    <a href="/epa-under-siege/" class="dib tc">
+      <img alt="Back Arrow" src="/assets/back.png" style="width:40px; margin-bottom:10px">
+      <h3 class="f5 fw1 ttu">Back to Main Article</h3>
+    </a>
+  </div>
+</div>

--- a/_includes/back-to-article-part2.html
+++ b/_includes/back-to-article-part2.html
@@ -1,0 +1,8 @@
+<div class="back-to-article dib mh3">
+  <div class="dib">
+    <a href="/pursuing-toxic-agenda/" class="dib tc">
+      <img alt="Back Arrow" src="/assets/back.png" style="width:40px; margin-bottom:10px">
+      <h3 class="f5 fw1 ttu">Back to Main Article</h3>
+    </a>
+  </div>
+</div>

--- a/_includes/back-to-top.html
+++ b/_includes/back-to-top.html
@@ -1,0 +1,8 @@
+<div class="back-to-top dib mh3 dn-ns dn-m dib-l">
+  <div class="dib">
+    <a href="#h.tdey93iuyhc0" class="dib tc">
+      <img alt="Top Arrow" src="/assets/top.png" class="" style="width:40px; margin-bottom:10px">
+      <h3 class="f5 fw1 ttu">Back to Table of Contents</h3>
+    </a>
+  </div>
+</div>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,5 +1,5 @@
 <footer class="dib w-100 mid-gray tc mt4 mb1 pv2 f6">
-    <a class="ma4 pa3" rel="license" href="https://creativecommons.org/licenses/by-nc-sa/4.0/"><img alt="Creative Commons Licence" style="border-width: 0;" src="https://licensebuttons.net/l/by-nc-sa/4.0/80x15.png" /></a><br />
-    This work is licensed under a <a rel="license" href="https://creativecommons.org/licenses/by-nc-sa/4.0/">Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License</a>.<br />
-    <strong><a class="mt3 pa3" href="https://envirodatagov.org">The Environmental Data &amp; Governance Initiative, 2017</a></strong>
+  <a class="ma4 pa3" rel="license" href="https://creativecommons.org/licenses/by-nc-sa/4.0/"><img alt="Creative Commons Licence" style="border-width: 0;" src="https://licensebuttons.net/l/by-nc-sa/4.0/80x15.png" /></a><br />
+  This work is licensed under a <a rel="license" href="https://creativecommons.org/licenses/by-nc-sa/4.0/">Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License</a>.<br />
+  <strong><a class="mt3 pa3" href="https://envirodatagov.org">The Environmental Data &amp; Governance Initiative, 2017</a></strong>
 </footer>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -3,7 +3,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
-  <title>{{ site.title }}{% if page.title %}: {{ page.title | strip | strip_html }}{% endif %} | {{ site.author }}</title>
+  <title>{{ site.title }}{% if page.title %}: Part {{ page.section | strip | strip_html }} - {{ page.title | strip | strip_html }}{% endif %} | {{ site.author }}</title>
   <meta name="description" content="{{ site.description }}">
   <link rel="canonical" href="{{ site.production_url }}{{ page.url | replace:'index.html',''}}">
   <link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="/feed.xml">
@@ -18,7 +18,7 @@
   <meta property="og:title" content="{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}"/>
   <meta property="og:type" content="article"/>
   <meta property="og:url" content="{{ site.production_url }}{{ page.url | replace:'index.html',''}}"/>
-  <meta property="og:description" content="{% if page.description %}{{ page.description }}{% else %}{{ site.description }}{% endif %}" />
+  <meta property="og:description" content="{% if page.description %}{{ page.description }} in {{ page.subtitle }}{% else %}{{ site.description }}{% endif %}" />
   <meta property="og:image" content="{{ site.production_url }}/assets/{% if page.og-image %}{{ page.og-image }}{% else %}flag-joe-raedle.jpg{% endif %}" />
 
   <!-- Twitter Card -->

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -1,0 +1,9 @@
+<div id="nav" class="w-100 pv1">
+  <a href="/index.html" title="Home">
+    <img id="nav-logo" alt="EDGI dark logo" src="/assets/edgi-logo-b.png">
+  </a>
+  <div id="nav-txt" class="di">
+    <h3 class="f5 ttu tl mb0 di">Part {{ page.section }}</h3>
+    <h3 class="f5 fw3 ttu tl mb0 di"> | {{ page.title }}</h3>
+  </div>
+</div>

--- a/epa-under-siege-peer-reviews.html
+++ b/epa-under-siege-peer-reviews.html
@@ -1,7 +1,8 @@
 ---
 layout: default
-title: "Part 1 Peer Reviews"
-description: "The EPA Under Siege: Trump's Assault in History and Testimony"
+section: "1"
+title: "Peer Reviews"
+subtitle: "The EPA Under Siege: Trump's Assault in History and Testimony"
 author: "Dr. Richard Andrews, Dr. Nancy Langston, Dr. Jay Turner"
 og-image: "ch1-cover.jpg"
 permalink: /epa-under-siege-peer-reviews/
@@ -15,12 +16,12 @@ redirect_from:
         <div id="h_wrapper">
             <div><a id="logo" href="/index.html" title="Home" class=""><img alt="edgi-logo" src="/assets/edgi-logo-b.png" style="width:5vh;min-width:35px; height:auto;"></a></div>
             <div id="bg1">
-                <div id="title"><h1 class="fw6 f-5-l f4-m f4-ns ttu">Peer Reviews</h1></div>
-                <div id="subtitle"><h2 class="f3 fw3 ttu">The EPA Under Siege: Trump’s Assault in History and Testimony</h2></div>
+                <div id="title"><h1 class="fw6 f-5-l f4-m f4-ns ttu">{{ page.title }}</h1></div>
+                <div id="subtitle"><h2 class="f3 fw3 ttu">{{ page.subtitle }}</h2></div>
 
             </div>
             <div id="intro_pr" class="intro tc pv4-ns">
-                <p class="f5-l f7-m f7-ns fw1 lh-copy">Dr. Richard Andrews, Dr. Nancy Langston, Dr. Jay Turner</p>
+                <p class="f5-l f7-m f7-ns fw1 lh-copy">{{ page.author }}</p>
             </div>
             <div id="down"></div>
         </div>
@@ -29,7 +30,7 @@ redirect_from:
         <a href="/index.html" title="Home" class="">
             <img id="nav-logo" src="/assets/edgi-logo-b.png">
         </a>
-        <div id="nav-txt" class="di"><h3 class="f5 ttu tl mb0 di">Part 1</h3><h3 class="f5 fw3 ttu tl mb0 di"> | Peer Reviews</h3></div>
+        <div id="nav-txt" class="di"><h3 class="f5 ttu tl mb0 di">Part {{ page.section }}</h3><h3 class="f5 fw3 ttu tl mb0 di"> | {{ page.title }}</h3></div>
     </div>
     <div class="back-to-article dib mh3">
         <div class="dib">

--- a/epa-under-siege-peer-reviews.html
+++ b/epa-under-siege-peer-reviews.html
@@ -27,13 +27,10 @@ redirect_from:
       </div>
   </header>
 
-  <!--NAVIGATION-->
-  <div id="nav" class="w-100 pv1">
-      <a href="/index.html" title="Home" class="">
-          <img id="nav-logo" src="/assets/edgi-logo-b.png">
-      </a>
-      <div id="nav-txt" class="di"><h3 class="f5 ttu tl mb0 di">Part {{ page.section }}</h3><h3 class="f5 fw3 ttu tl mb0 di"> | {{ page.title }}</h3></div>
-  </div>
+  <!--NAVIGATION TOP-->
+  {% include nav.html %}
+
+  <!--NAVIGATION SIDEBAR-->
   {% include back-to-article-part2.html %}
 
   <!--MAIN ARTICLE-->

--- a/epa-under-siege-peer-reviews.html
+++ b/epa-under-siege-peer-reviews.html
@@ -12,35 +12,31 @@ redirect_from:
 
 <body class="bg-white">
 
-    <header id="wrapper1">
-        <div id="h_wrapper">
-            <div><a id="logo" href="/index.html" title="Home" class=""><img alt="edgi-logo" src="/assets/edgi-logo-b.png" style="width:5vh;min-width:35px; height:auto;"></a></div>
-            <div id="bg1">
-                <div id="title"><h1 class="fw6 f-5-l f4-m f4-ns ttu">{{ page.title }}</h1></div>
-                <div id="subtitle"><h2 class="f3 fw3 ttu">{{ page.subtitle }}</h2></div>
+  <!--HEADER-->
+  <header id="wrapper1">
+      <div id="h_wrapper">
+          <div><a id="logo" href="/index.html" title="Home" class=""><img alt="edgi-logo" src="/assets/edgi-logo-b.png" style="width:5vh;min-width:35px; height:auto;"></a></div>
+          <div id="bg1">
+              <div id="title"><h1 class="fw6 f-5-l f4-m f4-ns ttu">{{ page.title }}</h1></div>
+              <div id="subtitle"><h2 class="f3 fw3 ttu">{{ page.subtitle }}</h2></div>
+          </div>
+          <div id="intro_pr" class="intro tc pv4-ns">
+              <p class="f5-l f7-m f7-ns fw1 lh-copy">{{ page.author }}</p>
+          </div>
+          <div id="down"></div>
+      </div>
+  </header>
 
-            </div>
-            <div id="intro_pr" class="intro tc pv4-ns">
-                <p class="f5-l f7-m f7-ns fw1 lh-copy">{{ page.author }}</p>
-            </div>
-            <div id="down"></div>
-        </div>
-    </header>
-    <div id="nav" class="w-100 pv1">
-        <a href="/index.html" title="Home" class="">
-            <img id="nav-logo" src="/assets/edgi-logo-b.png">
-        </a>
-        <div id="nav-txt" class="di"><h3 class="f5 ttu tl mb0 di">Part {{ page.section }}</h3><h3 class="f5 fw3 ttu tl mb0 di"> | {{ page.title }}</h3></div>
-    </div>
-    <div class="back-to-article dib mh3">
-        <div class="dib">
-            <a href="/epa-under-siege/" class="dib tc">
-                <img alt="back" src="/assets/back.png" style="width:40px; margin-bottom:10px">
-                <h3 class="f5 fw1 ttu">Back to Main Article</h3>
-            </a>
-        </div>
-    </div>
-    <!--MAIN ARTICLE-->
+  <!--NAVIGATION-->
+  <div id="nav" class="w-100 pv1">
+      <a href="/index.html" title="Home" class="">
+          <img id="nav-logo" src="/assets/edgi-logo-b.png">
+      </a>
+      <div id="nav-txt" class="di"><h3 class="f5 ttu tl mb0 di">Part {{ page.section }}</h3><h3 class="f5 fw3 ttu tl mb0 di"> | {{ page.title }}</h3></div>
+  </div>
+  {% include back-to-article-part2.html %}
+
+  <!--MAIN ARTICLE-->
 	<div class="article center measure-wide f5 pv5 lh-copy ph2">
         <p>EDGI&rsquo;s 100 Days and Counting Report on the early days of the Trump Administration is being peer reviewed by academics with expertise in the relevant content area. The reviewers have agreed to share their reviews.</p>
         <p>Peer review is a vital aspect of academic work, however the process of journal publication can be slow and create barriers to accessing academic work. In order to provide our academic analysis in a timely and freely accessible fashion EDGI is publishing open peer reviews along with each part of the report. Where possible, we have already revised the report based on the reviewers feedback.</p>

--- a/epa-under-siege.html
+++ b/epa-under-siege.html
@@ -1,7 +1,9 @@
 ---
 layout: default
-title: "Part 1 - The EPA Under Siege"
-description: "The EPA Under Siege: Trump's Assault in History and Testimony"
+section: "1"
+title: "The EPA Under Siege"
+subtitle: "The EPA Under Siege: Trump's Assault in History and Testimony"
+description:
 author: "Christopher Sellers, Lindsey Dillon, Jennifer Liss Ohayon, Nick Shapiro, Marianne Sullivan, Chris Amoss, Stephen Bocking, Phil Brown, Vanessa De la Rosa, Jill Harrison, Sara Johns, Katherine Kulik, Rebecca Lave, Michelle Murphy, Liza Piper, Lauren Richter, Sara Wylie"
 og-image: "ch1-cover.jpg"
 permalink: /epa-under-siege/
@@ -19,18 +21,18 @@ redirect_from:
         <a href="/index.html" title="Home" class="">
             <img id="nav-logo" src="/assets/edgi-logo-b.png">
         </a>
-        <div id="nav-txt" class="di"><h3 class="f5 ttu tl mb0 di">Part 1</h3><h3 class="f5 fw3 ttu tl mb0 di"> | The EPA Under Siege</h3></div>
+        <div id="nav-txt" class="di"><h3 class="f5 ttu tl mb0 di">Part {{ page.section }}</h3><h3 class="f5 fw3 ttu tl mb0 di"> | {{ page.title }}</h3></div>
     </div>
     <header id="wrapper1">
         <div id="h_wrapper">
             <div><a id="logo" href="/index.html" title="Home" class=""><img alt="edgi-logo" src="/assets/edgi-logo-b.png" style="width:5vh;min-width:35px; height:auto;"></a></div>
             <div id="bg1">
-                <div id="title"><h1 class="fw6 f-5-l f4-m f4-ns ttu">The EPA Under Siege</h1></div>
+                <div id="title"><h1 class="fw6 f-5-l f4-m f4-ns ttu">{{ page.title }}</h1></div>
                 <div id="subtitle"><h2 class="f3 fw3 ttu">Trump’s Assault in History and Testimony</h2></div>
 
             </div>
             <div class="intro tc pv4-ns">
-                <p class="f5-l f7-m f7-ns fw1 lh-copy">Christopher Sellers, Lindsey Dillon, Jennifer Liss Ohayon, Nick Shapiro, Marianne Sullivan, Chris Amoss, Stephen Bocking, Phil Brown, Vanessa De la Rosa, Jill Harrison, Sara Johns, Katherine Kulik, Rebecca Lave, Michelle Murphy, Liza Piper, Lauren Richter, Sara Wylie</p>
+                <p class="f5-l f7-m f7-ns fw1 lh-copy">{{ page.author }}</p>
             </div>
             <div id="down"></div>
         </div>

--- a/epa-under-siege.html
+++ b/epa-under-siege.html
@@ -32,13 +32,10 @@ redirect_from:
         </div>
     </header>
 
-    <!--NAVIGATION-->
-    <div id="nav" class="w-100 pv1">
-        <a href="/index.html" title="Home" class="">
-            <img id="nav-logo" src="/assets/edgi-logo-b.png">
-        </a>
-        <div id="nav-txt" class="di"><h3 class="f5 ttu tl mb0 di">Part {{ page.section }}</h3><h3 class="f5 fw3 ttu tl mb0 di"> | {{ page.title }}</h3></div>
-    </div>
+    <!--NAVIGATION TOP-->
+    {% include nav.html %}
+
+    <!--NAVIGATION SIDEBAR-->
     <div id="aside" class="pv5 mh6 dn-ns dn-m dib-l">
         <div class="aside">
             <a href="https://envirodatagov.org/wp-content/uploads/2017/06/Part-1-EPA-Under-Siege.pdf" class="aside-el">

--- a/epa-under-siege.html
+++ b/epa-under-siege.html
@@ -3,7 +3,6 @@ layout: default
 section: "1"
 title: "The EPA Under Siege"
 subtitle: "The EPA Under Siege: Trump's Assault in History and Testimony"
-description:
 author: "Christopher Sellers, Lindsey Dillon, Jennifer Liss Ohayon, Nick Shapiro, Marianne Sullivan, Chris Amoss, Stephen Bocking, Phil Brown, Vanessa De la Rosa, Jill Harrison, Sara Johns, Katherine Kulik, Rebecca Lave, Michelle Murphy, Liza Piper, Lauren Richter, Sara Wylie"
 og-image: "ch1-cover.jpg"
 permalink: /epa-under-siege/

--- a/epa-under-siege.html
+++ b/epa-under-siege.html
@@ -2,7 +2,7 @@
 layout: default
 section: "1"
 title: "The EPA Under Siege"
-subtitle: "The EPA Under Siege: Trump's Assault in History and Testimony"
+subtitle: "Trump's Assault in History and Testimony"
 author: "Christopher Sellers, Lindsey Dillon, Jennifer Liss Ohayon, Nick Shapiro, Marianne Sullivan, Chris Amoss, Stephen Bocking, Phil Brown, Vanessa De la Rosa, Jill Harrison, Sara Johns, Katherine Kulik, Rebecca Lave, Michelle Murphy, Liza Piper, Lauren Richter, Sara Wylie"
 og-image: "ch1-cover.jpg"
 permalink: /epa-under-siege/
@@ -16,18 +16,13 @@ redirect_from:
         $("#nav").sticky({topSpacing:0, wrapperClassName:"nav-wrapper"});
     });
     </script>
-    <div id="nav" class="w-100 pv1">
-        <a href="/index.html" title="Home" class="">
-            <img id="nav-logo" src="/assets/edgi-logo-b.png">
-        </a>
-        <div id="nav-txt" class="di"><h3 class="f5 ttu tl mb0 di">Part {{ page.section }}</h3><h3 class="f5 fw3 ttu tl mb0 di"> | {{ page.title }}</h3></div>
-    </div>
+    <!--HEADER-->
     <header id="wrapper1">
         <div id="h_wrapper">
             <div><a id="logo" href="/index.html" title="Home" class=""><img alt="edgi-logo" src="/assets/edgi-logo-b.png" style="width:5vh;min-width:35px; height:auto;"></a></div>
             <div id="bg1">
                 <div id="title"><h1 class="fw6 f-5-l f4-m f4-ns ttu">{{ page.title }}</h1></div>
-                <div id="subtitle"><h2 class="f3 fw3 ttu">Trump’s Assault in History and Testimony</h2></div>
+                <div id="subtitle"><h2 class="f3 fw3 ttu">{{ page.subtitle }}</h2></div>
 
             </div>
             <div class="intro tc pv4-ns">
@@ -37,6 +32,13 @@ redirect_from:
         </div>
     </header>
 
+    <!--NAVIGATION-->
+    <div id="nav" class="w-100 pv1">
+        <a href="/index.html" title="Home" class="">
+            <img id="nav-logo" src="/assets/edgi-logo-b.png">
+        </a>
+        <div id="nav-txt" class="di"><h3 class="f5 ttu tl mb0 di">Part {{ page.section }}</h3><h3 class="f5 fw3 ttu tl mb0 di"> | {{ page.title }}</h3></div>
+    </div>
     <div id="aside" class="pv5 mh6 dn-ns dn-m dib-l">
         <div class="aside">
             <a href="https://envirodatagov.org/wp-content/uploads/2017/06/Part-1-EPA-Under-Siege.pdf" class="aside-el">
@@ -53,16 +55,7 @@ redirect_from:
             </a>
         </div>
     </div>
-
-    <div class="back-to-top dib mh3 dn-ns dn-m dib-l">
-        <div class="dib">
-            <a href="#h.ndno7y5z1mor" class="dib tc">
-                <img alt="top" src="/assets/top.png" class="" style="width:40px; margin-bottom:10px">
-                <h3 class="f5 fw1 ttu">Back to Table of Contents</h3>
-            </a>
-        </div>
-    </div>
-
+    {% include back-to-top.html %}
 
     <!--MAIN ARTICLE-->
 	<main class="article center measure-wide f5 pt5 lh-copy ph2">

--- a/mustafa-ali-interview.html
+++ b/mustafa-ali-interview.html
@@ -1,7 +1,8 @@
 ---
 layout: default
+section: "2"
 title: "Interview With Mustafa Ali"
-description: "Former head of the EPA Office of Environmental Justice"
+subtitle: "Former head of the EPA Office of Environmental Justice"
 author: "Lindsey Dillon"
 og-image: "mustafa.jpg"
 permalink: /mustafa-ali-interview/
@@ -13,10 +14,10 @@ redirect_from:
     <header id="wrapper2">
         <div id="bg2a" class="chbg"></div>
         <div id="p2-inner-wrapper">
-            <div class="part"><h2 class="f3 ttu">Part 2</h2></div>
-              <h1 class="f-6-l f4-m f4-ns ttu tl">INTERVIEW WITH MUSTAFA ALI</h1>
-              <h2 class="f3 fw3 ttu tl pv2">Former head of the EPA Office of Environmental Justice</h2>
-              <p id="contrib"class="f5-l f7-m f7-ns fw1 lh-copy">Conducted by Lindsey Dillon</p>
+            <div class="part"><h2 class="f3 ttu">Part {{ page.section }}</h2></div>
+              <h1 class="f-6-l f4-m f4-ns ttu tl">{{ page.title }}</h1>
+              <h2 class="f3 fw3 ttu tl pv2">{{ page.subtitle }}</h2>
+              <p id="contrib"class="f5-l f7-m f7-ns fw1 lh-copy">Conducted by {{ page.author }}</p>
         </div>
     </header>
 
@@ -24,7 +25,7 @@ redirect_from:
         <a href="/index.html" title="Home" class="">
             <img id="nav-logo" src="/assets/edgi-logo-b.png">
         </a>
-        <div id="nav-txt" class="di"><h3 class="f5 ttu tl mb0 di">Part 2</h3><h3 class="f5 fw3 ttu tl mb0 di"> | INTERVIEW WITH MUSTAFA ALI</h3></div>
+        <div id="nav-txt" class="di"><h3 class="f5 ttu tl mb0 di">Part {{ page.section }}</h3><h3 class="f5 fw3 ttu tl mb0 di"> | {{ page.title }}</h3></div>
     </div>
     <!-- <div id="aside" class="pv6 mh6 dn-ns dn-m dib-l">
         <div class="aside">

--- a/mustafa-ali-interview.html
+++ b/mustafa-ali-interview.html
@@ -22,13 +22,10 @@ redirect_from:
         </div>
     </header>
 
-    <!--NAVIGATION-->
-    <div id="nav" class="w-100 pv1">
-        <a href="/index.html" title="Home" class="">
-            <img id="nav-logo" src="/assets/edgi-logo-b.png">
-        </a>
-        <div id="nav-txt" class="di"><h3 class="f5 ttu tl mb0 di">Part {{ page.section }}</h3><h3 class="f5 fw3 ttu tl mb0 di"> | {{ page.title }}</h3></div>
-    </div>
+    <!--NAVIGATION TOP-->
+    {% include nav.html %}
+
+    <!--NAVIGATION SIDEBAR-->
     <!-- <div id="aside" class="pv6 mh6 dn-ns dn-m dib-l">
         <div class="aside">
             <a href="https://envirodatagov.org/wp-content/uploads/2017/09/Part-2-Pursuing-Toxic-Agenda.pdf" class="aside-el">

--- a/mustafa-ali-interview.html
+++ b/mustafa-ali-interview.html
@@ -10,6 +10,7 @@ redirect_from:
   - 'mustafa-ali-interview.html'
 ---
 <body class="bg-white">
+    <!--HEADER-->
     <div><a id="logo" href="/index.html" title="Home" class=""><img alt="edgi-logo" src="/assets/edgi-logo-b.png" style="width:5vh;min-width:35px; height:auto;"></a></div>
     <header id="wrapper2">
         <div id="bg2a" class="chbg"></div>
@@ -21,6 +22,7 @@ redirect_from:
         </div>
     </header>
 
+    <!--NAVIGATION-->
     <div id="nav" class="w-100 pv1">
         <a href="/index.html" title="Home" class="">
             <img id="nav-logo" src="/assets/edgi-logo-b.png">
@@ -39,15 +41,8 @@ redirect_from:
             </a>
         </div>
     </div> -->
+    {% include back-to-article-part2.html %}
 
-    <div class="back-to-article dib mh3">
-        <div class="dib">
-            <a href="/pursuing-toxic-agenda/" class="dib tc">
-                <img alt="back" src="/assets/back.png" style="width:40px; margin-bottom:10px">
-                <h3 class="f5 fw1 ttu">Back to Main Article</h3>
-            </a>
-        </div>
-    </div>
     <div class="article center measure-wide f5 pt5 pb2 lh-copy ph2">
 
         <a id="id.qskbsdioqlsb"></a>

--- a/pursuing-toxic-agenda-data.html
+++ b/pursuing-toxic-agenda-data.html
@@ -23,13 +23,10 @@ redirect_from:
         </div>
     </header>
 
-    <!--NAVIGATION-->
-    <div id="nav" class="w-100 pv1">
-        <a href="/index.html" title="Home" class="">
-            <img id="nav-logo" src="/assets/edgi-logo-b.png">
-        </a>
-        <div id="nav-txt" class="di"><h3 class="f5 ttu tl mb0 di">Part {{ page.section }}</h3><h3 class="f5 fw3 ttu tl mb0 di"> | {{ page.title }}</h3></div>
-    </div>
+    <!--NAVIGATION TOP-->
+    {% include nav.html %}
+
+    <!--NAVIGATION SIDEBAR-->
     {% include back-to-article-part2.html %}
 
     <main class="article center measure-wide f5 pb1 pt5 lh-copy ph2">

--- a/pursuing-toxic-agenda-data.html
+++ b/pursuing-toxic-agenda-data.html
@@ -11,6 +11,7 @@ redirect_from:
     - '/pursuing-toxic-agenda-data.html'
 ---
 <body>
+    <!--HEADER-->
     <div><a id="logo" href="/index.html" title="Home" class=""><img alt="edgi-logo" src="/assets/edgi-logo-b.png" style="width:5vh;min-width:35px; height:auto;"></a></div>
     <header id="wrapper2">
         <div id="bg2" class="chbg"></div>
@@ -21,20 +22,16 @@ redirect_from:
               <p id="contrib"class="f5-l f7-m f7-ns fw1 lh-copy">{{ page.author }}</p>
         </div>
     </header>
+
+    <!--NAVIGATION-->
     <div id="nav" class="w-100 pv1">
         <a href="/index.html" title="Home" class="">
             <img id="nav-logo" src="/assets/edgi-logo-b.png">
         </a>
         <div id="nav-txt" class="di"><h3 class="f5 ttu tl mb0 di">Part {{ page.section }}</h3><h3 class="f5 fw3 ttu tl mb0 di"> | {{ page.title }}</h3></div>
     </div>
-    <div class="back-to-article dib mh3">
-        <div class="dib">
-            <a href="/pursuing-toxic-agenda/" class="dib tc">
-                <img alt="back" src="/assets/back.png" style="width:40px; margin-bottom:10px">
-                <h3 class="f5 fw1 ttu">Back to Main Article</h3>
-            </a>
-        </div>
-    </div>
+    {% include back-to-article-part2.html %}
+
     <main class="article center measure-wide f5 pb1 pt5 lh-copy ph2">
         <p>EDGI emphasizes good data practices which includes proper contextualization of data used in reports. Here we add some notes on data used in Figures 4, 5, and 6 in the online report. For figure 4 we show Pipeline and Hazardous Materials Safety Administration (PHMSA) columns of interest to show that pipelines leak. Figure 5 is an infographic that gathers data from many different sources to show the ways in which its agricultural use is dangerous to farmworkers and their families. Figure 6 combines U.S. Geological Survey (USGS), National Water Quality Program, respectively, with Census data downloaded from the <a href="https://www.census.gov/did/www/saipe/about/index.html">Small Area Income and Poverty (SAIPE) </a>program tool. We combine data on income and chlorpyrifos use because this report focuses on environmental justice, which attends to how environmental health risks are unevenly spread throughout the country with regard to environmental damage and income. We hope providing this data together creates opportunities for readers to further research the connections between income, pipeline spills, and other important factors such as race/ethnicity.
         <!-- If readers wish to build on this analysis, the data sets and map used are hosted on github (link) and available under licence____. -->

--- a/pursuing-toxic-agenda-data.html
+++ b/pursuing-toxic-agenda-data.html
@@ -1,6 +1,8 @@
 ---
 layout: default
-title: "Part 2 - Data Methods"
+section: "2"
+title: "Data Methods"
+subtitle: "Pursuing a Toxic Agenda: Environmental Injustice in the Early Trump Administration"
 description: "Notes on Data Used in Figures"
 author: "Britt S. Paris, Shaquilla Singh, Sara Wylie"
 og-image: "ch2-cover.jpg"
@@ -13,9 +15,9 @@ redirect_from:
     <header id="wrapper2">
         <div id="bg2" class="chbg"></div>
         <div id="p2-inner-wrapper">
-            <div class="part"><h2 class="f3 ttu">Part 2</h2></div>
-              <h1 class="f-6-l f4-m f4-ns ttu tl">Data Methods</h1>
-              <h2 class="f3 fw3 ttu tl pv2">Notes on Data Used in Figures in PURSUING A TOXIC AGENDA: Environmental Injustice in the Early Trump Administration</h2>
+            <div class="part"><h2 class="f3 ttu">Part {{ page.section }}</h2></div>
+              <h1 class="f-6-l f4-m f4-ns ttu tl">{{ page.title }}</h1>
+              <h2 class="f3 fw3 ttu tl pv2">{{ page.description }} in {{ page.subtitle }}</h2>
               <p id="contrib"class="f5-l f7-m f7-ns fw1 lh-copy">{{ page.author }}</p>
         </div>
     </header>
@@ -23,7 +25,7 @@ redirect_from:
         <a href="/index.html" title="Home" class="">
             <img id="nav-logo" src="/assets/edgi-logo-b.png">
         </a>
-        <div id="nav-txt" class="di"><h3 class="f5 ttu tl mb0 di">Part 2</h3><h3 class="f5 fw3 ttu tl mb0 di"> | Data Methods</h3></div>
+        <div id="nav-txt" class="di"><h3 class="f5 ttu tl mb0 di">Part {{ page.section }}</h3><h3 class="f5 fw3 ttu tl mb0 di"> | {{ page.title }}</h3></div>
     </div>
     <div class="back-to-article dib mh3">
         <div class="dib">

--- a/pursuing-toxic-agenda-data.html
+++ b/pursuing-toxic-agenda-data.html
@@ -3,7 +3,7 @@ layout: default
 section: "2"
 title: "Data Methods"
 subtitle: "Pursuing a Toxic Agenda: Environmental Injustice in the Early Trump Administration"
-description: "Notes on Data Used in Figures"
+description: "Notes on Data Used in Part Figures"
 author: "Britt S. Paris, Shaquilla Singh, Sara Wylie"
 og-image: "ch2-cover.jpg"
 permalink: /pursuing-toxic-agenda-data/

--- a/pursuing-toxic-agenda-peer-reviews.html
+++ b/pursuing-toxic-agenda-peer-reviews.html
@@ -11,16 +11,7 @@ redirect_from:
 ---
 
 <body class="bg-white">
-
-    <div id="nav" class="w-100 pv1">
-        <a href="/index.html" title="Home">
-            <img id="nav-logo" src="/assets/edgi-logo-b.png">
-        </a>
-
-        <div id="nav-txt" class="di">
-            <h3 class="f5 ttu tl mb0 di">Part {{ page.section }}</h3>
-            <h3 class="f5 fw3 ttu tl mb0 di"> | {{ page.title }}</h3></div>
-    </div>
+    <!--HEADER-->
     <header id="wrapper2">
         <div id="bg2" class="chbg"></div>
         <div id="p2-inner-wrapper">
@@ -31,16 +22,17 @@ redirect_from:
         </div>
     </header>
 
+    <!--NAVIGATION-->
+    <div id="nav" class="w-100 pv1">
+        <a href="/index.html" title="Home">
+            <img id="nav-logo" src="/assets/edgi-logo-b.png">
+        </a>
 
-
-    <div class="back-to-article dib mh3">
-        <div class="dib">
-            <a href="/pursuing-toxic-agenda/" class="dib tc">
-                <img alt="back" src="/assets/back.png" style="width:40px; margin-bottom:10px">
-                <h3 class="f5 fw1 ttu">Back to Main Article</h3>
-            </a>
-        </div>
+        <div id="nav-txt" class="di">
+            <h3 class="f5 ttu tl mb0 di">Part {{ page.section }}</h3>
+            <h3 class="f5 fw3 ttu tl mb0 di"> | {{ page.title }}</h3></div>
     </div>
+    {% include back-to-article-part2.html %}
 
     <!--MAIN ARTICLE-->
     <main class="article center measure-wide f5 pb1 pt5 lh-copy ph2" style="overflow-x:visible;">

--- a/pursuing-toxic-agenda-peer-reviews.html
+++ b/pursuing-toxic-agenda-peer-reviews.html
@@ -22,16 +22,10 @@ redirect_from:
         </div>
     </header>
 
-    <!--NAVIGATION-->
-    <div id="nav" class="w-100 pv1">
-        <a href="/index.html" title="Home">
-            <img id="nav-logo" src="/assets/edgi-logo-b.png">
-        </a>
+    <!--NAVIGATION TOP-->
+    {% include nav.html %}
 
-        <div id="nav-txt" class="di">
-            <h3 class="f5 ttu tl mb0 di">Part {{ page.section }}</h3>
-            <h3 class="f5 fw3 ttu tl mb0 di"> | {{ page.title }}</h3></div>
-    </div>
+    <!--NAVIGATION SIDEBAR-->
     {% include back-to-article-part2.html %}
 
     <!--MAIN ARTICLE-->

--- a/pursuing-toxic-agenda-peer-reviews.html
+++ b/pursuing-toxic-agenda-peer-reviews.html
@@ -1,7 +1,8 @@
 ---
 layout: default
-title: "Part II Peer Reviews"
-description: "Pursuing a Toxic Agenda: Environmental Injustice in the Early Trump Administration"
+section: "2"
+title: "Peer Reviews"
+subtitle: "Pursuing a Toxic Agenda: Environmental Injustice in the Early Trump Administration"
 author: "Dr. Jill Harrison, Dr. Ellen Kohl"
 og-image: "ch2-cover.jpg"
 permalink: /pursuing-toxic-agenda-peer-reviews/
@@ -17,16 +18,16 @@ redirect_from:
         </a>
 
         <div id="nav-txt" class="di">
-            <h3 class="f5 ttu tl mb0 di">Part 2</h3>
-            <h3 class="f5 fw3 ttu tl mb0 di"> | Peer reviews</h3></div>
+            <h3 class="f5 ttu tl mb0 di">Part {{ page.section }}</h3>
+            <h3 class="f5 fw3 ttu tl mb0 di"> | {{ page.title }}</h3></div>
     </div>
     <header id="wrapper2">
         <div id="bg2" class="chbg"></div>
         <div id="p2-inner-wrapper">
-            <div class="part"><h2 class="f3 ttu">Part 2</h2></div>
-              <h1 class="f-6-l f4-m f4-ns ttu tl">Peer Reviews</h1>
-              <h2 class="f3 fw3 ttu tl pv2">Pursuing a Toxic Agenda: Environmental Injustice in the Early Trump Administration</h2>
-              <p id="contrib"class="f5-l f7-m f7-ns fw1 lh-copy">Dr. Jill Harrison, Dr. Ellen Kohl</p>
+            <div class="part"><h2 class="f3 ttu">Part {{ page.section }}</h2></div>
+              <h1 class="f-6-l f4-m f4-ns ttu tl">{{ page.title }}</h1>
+              <h2 class="f3 fw3 ttu tl pv2">{{ page.subtitle }}</h2>
+              <p id="contrib"class="f5-l f7-m f7-ns fw1 lh-copy">{{ page.author }}</p>
         </div>
     </header>
 

--- a/pursuing-toxic-agenda.html
+++ b/pursuing-toxic-agenda.html
@@ -11,7 +11,7 @@ redirect_from:
 ---
 <body class="bg-white">
     <!--HEADER-->
-    <div><a id="logo" href="/index.html" title="Home" class=""><img alt="edgi-logo" src="/assets/edgi-logo-b.png" style="width:5vh;min-width:35px; height:auto;"></a></div>
+    <div><a id="logo" href="/index.html" title="Home" class=""><img alt="EDGI dark logo" src="/assets/edgi-logo-b.png" style="width:5vh; min-width:35px; height:auto;"></a></div>
     <header id="wrapper2">
         <div id="bg2" class="chbg"></div>
         <div id="p2-inner-wrapper">
@@ -22,14 +22,10 @@ redirect_from:
         </div>
     </header>
 
-    <!--NAVIGATION-->
-    <div id="nav" class="w-100 pv1">
-        <a href="/index.html" title="Home" class="">
-            <img id="nav-logo" src="/assets/edgi-logo-b.png">
-        </a>
-        <div id="nav-txt" class="di"><h3 class="f5 ttu tl mb0 di">Part {{ page.section }}</h3><h3 class="f5 fw3 ttu tl mb0 di"> | {{ page.title }}</h3></div>
-    </div>
+    <!--NAVIGATION TOP-->
+    {% include nav.html %}
 
+    <!--NAVIGATION SIDEBAR-->
     <div id="aside" class="pv5 mh6 dn-ns dn-m dib-l">
         <div class="aside">
             <a href="https://envirodatagov.org/wp-content/uploads/2017/09/Part-2-Pursuing-Toxic-Agenda.pdf" class="aside-el">

--- a/pursuing-toxic-agenda.html
+++ b/pursuing-toxic-agenda.html
@@ -10,6 +10,7 @@ redirect_from:
   - 'pursuing-toxic-agenda.html'
 ---
 <body class="bg-white">
+    <!--HEADER-->
     <div><a id="logo" href="/index.html" title="Home" class=""><img alt="edgi-logo" src="/assets/edgi-logo-b.png" style="width:5vh;min-width:35px; height:auto;"></a></div>
     <header id="wrapper2">
         <div id="bg2" class="chbg"></div>
@@ -20,6 +21,8 @@ redirect_from:
               <p id="contrib"class="f5-l f7-m f7-ns fw1 lh-copy">{{ page.author }}</p>
         </div>
     </header>
+
+    <!--NAVIGATION-->
     <div id="nav" class="w-100 pv1">
         <a href="/index.html" title="Home" class="">
             <img id="nav-logo" src="/assets/edgi-logo-b.png">
@@ -52,15 +55,7 @@ redirect_from:
             </a> -->
         </div>
     </div>
-
-    <div class="back-to-top dib mh3 dn-ns dn-m dib-l">
-        <div class="dib">
-            <a href="#h.tdey93iuyhc0" class="dib tc">
-                <img alt="top" src="/assets/top.png" class="" style="width:40px; margin-bottom:10px">
-                <h3 class="f5 fw1 ttu">Back to Table of Contents</h3>
-            </a>
-        </div>
-    </div>
+    {% include back-to-top.html %}
 
     <!--MAIN ARTICLE-->
     <main class="article center measure-wide f5 pt5 pb1 lh-copy ph2">

--- a/pursuing-toxic-agenda.html
+++ b/pursuing-toxic-agenda.html
@@ -1,7 +1,8 @@
 ---
 layout: default
-title: "Part 2 - Pursuing a Toxic Agenda"
-description: "Environmental Injustice in the Early Trump Administration"
+section: "2"
+title: "Pursuing a Toxic Agenda"
+subtitle: "Environmental Injustice in the Early Trump Administration"
 author: "Britt S. Paris, Lindsey Dillon, Jennifer Pierre, Irene V. Pasquetto, Emily Marquez, Sara Wylie, Michelle Murphy, Phil Brown, Rebecca Lave, Chris Sellers, Becky Mansfield, Leif Fredrickson, Nicholas Shapiro, EDGI"
 og-image: "ch2-cover.jpg"
 permalink: /pursuing-toxic-agenda/
@@ -13,17 +14,17 @@ redirect_from:
     <header id="wrapper2">
         <div id="bg2" class="chbg"></div>
         <div id="p2-inner-wrapper">
-            <div class="part"><h2 class="f3 ttu">Part 2</h2></div>
-              <h1 class="f-6-l f4-m f4-ns ttu tl">PURSUING A TOXIC AGENDA</h1>
-              <h2 class="f3 fw3 ttu tl pv2">Environmental Injustice in the Early Trump Administration</h2>
-              <p id="contrib"class="f5-l f7-m f7-ns fw1 lh-copy">Britt S. Paris, Lindsey Dillon, Jennifer Pierre, Irene V. Pasquetto, Emily Marquez, Sara Wylie, Michelle Murphy, Phil Brown, Rebecca Lave, Chris Sellers, Becky Mansfield, Leif Fredrickson, Nicholas Shapiro, EDGI</p>
+            <div class="part"><h2 class="f3 ttu">Part {{ page.section }}</h2></div>
+              <h1 class="f-6-l f4-m f4-ns ttu tl">{{ page.title }}</h1>
+              <h2 class="f3 fw3 ttu tl pv2">{{ page.subtitle }}</h2>
+              <p id="contrib"class="f5-l f7-m f7-ns fw1 lh-copy">{{ page.author }}</p>
         </div>
     </header>
     <div id="nav" class="w-100 pv1">
         <a href="/index.html" title="Home" class="">
             <img id="nav-logo" src="/assets/edgi-logo-b.png">
         </a>
-        <div id="nav-txt" class="di"><h3 class="f5 ttu tl mb0 di">Part 2</h3><h3 class="f5 fw3 ttu tl mb0 di"> | Pursuing a Toxic Agenda</h3></div>
+        <div id="nav-txt" class="di"><h3 class="f5 ttu tl mb0 di">Part {{ page.section }}</h3><h3 class="f5 fw3 ttu tl mb0 di"> | {{ page.title }}</h3></div>
     </div>
 
     <div id="aside" class="pv5 mh6 dn-ns dn-m dib-l">
@@ -924,5 +925,5 @@ redirect_from:
 
     <!--FOOTER-->
     {% include footer.html %}
-    
+
 </body>


### PR DESCRIPTION
This PR sets us up to take better advantage of Jekyll's templating and liquid tags --

- [x] better, separate metadata in yaml variables
- [x] swap in variables for each page
- [x] pull out `back-to-top` and `back-to-article` sections to includes
- [x] pull out `nav` section to includes
- ~[ ] pull out `logo` section to includes~

potentially: refactor `back-to-article` so there is only one (feed in path?)
  