### PR TITLE
Jekyll-ify header, replaces #67

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,13 +1,13 @@
 <footer class="flex w-100 mid-gray mb1 ph4 pv2 f6">
-    <div id="footer_cc">
-        <small>This work is licensed under a <a rel="license" href="https://creativecommons.org/licenses/by-nc-sa/4.0/">Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License</a>.</small>
+  <div id="footer_cc">
+    <small>This work is licensed under a <a rel="license" href="https://creativecommons.org/licenses/by-nc-sa/4.0/">Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License</a>.</small>
+  </div>
+  <div id="footer_edg">
+    <small class="mt2 pr3"><a class="black" href="https://envirodatagov.org">The Environmental Data &amp; Governance Initiative, 2017</a></small>
+    <div>
+      <a href="https://twitter.com/EnviroDGI" target="_blank" rel="noopener"><img class="social" src="/assets/tw.svg"/></a>
+      <a href="https://www.facebook.com/EnviroDGI/" target="_blank" rel="noopener"><img class="social" src="/assets/fb.svg"/></a>
+      <a href="https://www.instagram.com/envirodgi/" target="_blank" rel="noopener"><img class="social" src="/assets/ig.png"/></a>
     </div>
-    <div id="footer_edg">
-        <small class="mt2 pr3"><a class="black" href="https://envirodatagov.org">The Environmental Data &amp; Governance Initiative, 2017</a></small>
-        <div>
-            <a href="https://twitter.com/EnviroDGI" target="_blank" rel="noopener"><img class="social" src="/assets/tw.svg"/></a>
-            <a href="https://www.facebook.com/EnviroDGI/" target="_blank" rel="noopener"><img class="social" src="/assets/fb.svg"/></a>
-            <a href="https://www.instagram.com/envirodgi/" target="_blank" rel="noopener"><img class="social" src="/assets/ig.png"/></a>
-        </div>
-    </div>
+  </div>
 </footer>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -18,7 +18,7 @@
   <meta property="og:title" content="{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}"/>
   <meta property="og:type" content="article"/>
   <meta property="og:url" content="{{ site.production_url }}{{ page.url | replace:'index.html',''}}"/>
-  <meta property="og:description" content="{% if page.description %}{{ page.description }}{% else %}{{ site.description }}{% endif %}" />
+  <meta property="og:description" content="{% if page.description %}{{ page.description }} | {{ page.subtitle }}{% else %}{{ site.description }}{% endif %}" />
   <meta property="og:image" content="{{ site.production_url }}/assets/{% if page.og-image %}{{ page.og-image }}{% else %}flag-joe-raedle.jpg{% endif %}" />
 
   <!-- Twitter Card -->

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -1,0 +1,6 @@
+<div id="nav" class="w-100 pv1">
+  <a href="/index.html" title="Home" class="">
+    <img id="nav-logo" src="/assets/edgi-logo-b.png">
+  </a>
+  <div id="nav-txt" class="di"><h3 class="f5 ttu tl mb0 di">Part {{ page.section }}</h3><h3 class="f5 fw3 ttu tl mb0 di"> | {{ page.title }}</h3></div>
+</div>

--- a/epa-under-siege-peer-reviews.html
+++ b/epa-under-siege-peer-reviews.html
@@ -13,22 +13,19 @@ redirect_from:
 <body class="bg-white">
     <div><a id="logo" href="/index.html" title="Home" class=""><img alt="edgi-logo" src="/assets/edgi-logo-b.png" style="width:5vh;min-width:35px; height:auto;"></a></div>
     <header>
-        <div id="bg1" class="chbg"></div>
-        <div id="inner-wrapper">
-            <div id="heds">
-                <h2 class="f3 ttu tl">Part {{ page.section }}</h2>
-                <h1 class="f-6-l f4-m f4-ns ttu tl">{{ page.title }}</h1>
-                <h2 class="f3 fw3 ttu tl pv2">{{ page.subtitle }}</h2>
-            </div>
-              <p id="contrib" class="f5-l f7-m f7-ns fw1 lh-copy">{{ page.author }}</p>
+      <div id="bg1" class="chbg"></div>
+      <div id="inner-wrapper">
+        <div id="heds">
+          <h2 class="f3 ttu tl">Part {{ page.section }}</h2>
+          <h1 class="f-6-l f4-m f4-ns ttu tl">{{ page.title }}</h1>
+          <h2 class="f3 fw3 ttu tl pv2">{{ page.subtitle }}</h2>
         </div>
+          <p id="contrib" class="f5-l f7-m f7-ns fw1 lh-copy">{{ page.author }}</p>
+      </div>
     </header>
-    <div id="nav" class="w-100 pv1">
-        <a href="/index.html" title="Home" class="">
-            <img id="nav-logo" src="/assets/edgi-logo-b.png">
-        </a>
-        <div id="nav-txt" class="di"><h3 class="f5 ttu tl mb0 di">Part 1</h3><h3 class="f5 fw3 ttu tl mb0 di"> | Peer Reviews</h3></div>
-    </div>
+    
+    <!--NAVIGATION TOP-->
+    {% include nav.html %}
 
     <main class="flex">
         <div class="left-sidebar">

--- a/epa-under-siege-peer-reviews.html
+++ b/epa-under-siege-peer-reviews.html
@@ -1,7 +1,8 @@
 ---
 layout: default
-title: "Part 1 Peer Reviews"
-description: "The EPA Under Siege: Trump's Assault in History and Testimony"
+section: "1"
+title: "Peer Reviews"
+subtitle: "The EPA Under Siege: Trump's Assault in History and Testimony"
 author: "Dr. Richard Andrews, Dr. Nancy Langston, Dr. Jay Turner"
 og-image: "ch1-cover.jpg"
 permalink: /epa-under-siege-peer-reviews/
@@ -15,11 +16,11 @@ redirect_from:
         <div id="bg1" class="chbg"></div>
         <div id="inner-wrapper">
             <div id="heds">
-                <h2 class="f3 ttu tl">Part 1</h2>
-                <h1 class="f-6-l f4-m f4-ns ttu tl">Peer Reviews</h1>
-                <h2 class="f3 fw3 ttu tl pv2">The EPA Under Siege: Trump’s Assault in History and Testimony</h2>
+                <h2 class="f3 ttu tl">Part {{ page.section }}</h2>
+                <h1 class="f-6-l f4-m f4-ns ttu tl">{{ page.title }}</h1>
+                <h2 class="f3 fw3 ttu tl pv2">{{ page.subtitle }}</h2>
             </div>
-              <p id="contrib" class="f5-l f7-m f7-ns fw1 lh-copy">Dr. Richard Andrews, Dr. Nancy Langston, Dr. Jay Turner</p>
+              <p id="contrib" class="f5-l f7-m f7-ns fw1 lh-copy">{{ page.author }}</p>
         </div>
     </header>
     <div id="nav" class="w-100 pv1">

--- a/epa-under-siege.html
+++ b/epa-under-siege.html
@@ -27,12 +27,10 @@ redirect_from:
             </div>
         </div>
     </header>
-    <div id="nav" class="w-100 pv1">
-        <a href="/index.html" title="Home" class="">
-            <img id="nav-logo" src="/assets/edgi-logo-b.png">
-        </a>
-        <div id="nav-txt" class="di"><h3 class="f5 ttu tl mb0 di">Part 1</h3><h3 class="f5 fw3 ttu tl mb0 di"> | The EPA Under Siege</h3></div>
-    </div>
+    
+    <!--NAVIGATION TOP-->
+    {% include nav.html %}
+
 
     <main class="flex">
         <div class="left-sidebar">

--- a/epa-under-siege.html
+++ b/epa-under-siege.html
@@ -1,7 +1,9 @@
 ---
 layout: default
-title: "Part 1 - The EPA Under Siege"
-description: "The EPA Under Siege: Trump's Assault in History and Testimony"
+section: "1"
+title: "The EPA Under Siege"
+subtitle: "The EPA Under Siege: Trump's Assault in History and Testimony"
+description:
 author: "Christopher Sellers, Lindsey Dillon, Jennifer Liss Ohayon, Nick Shapiro, Marianne Sullivan, Chris Amoss, Stephen Bocking, Phil Brown, Vanessa De la Rosa, Jill Harrison, Sara Johns, Katherine Kulik, Rebecca Lave, Michelle Murphy, Liza Piper, Lauren Richter, Sara Wylie"
 og-image: "ch1-cover.jpg"
 permalink: /epa-under-siege/
@@ -16,12 +18,12 @@ redirect_from:
         <div id="bg1" class="chbg"></div>
         <div id="inner-wrapper">
             <div id="heds">
-                <h2 class="f3 ttu tl pv0">Part 1</h2>
-                <h1 class="f-6-l f4-m f4-ns ttu tl pv0">The EPA Under Siege</h1>
-                <h2 class="f3 fw3 ttu tl pv0">Trump’s Assault in History and Testimony</h2>
+                <h2 class="f3 ttu tl pv0">Part {{ page.section }}</h2>
+                <h1 class="f-6-l f4-m f4-ns ttu tl pv0">{{ page.title }}</h1>
+                <h2 class="f3 fw3 ttu tl pv0">{{ page.subtitle }}</h2>
             </div>
             <div>
-              <p id="contrib" class="f5-l f7-m f7-ns fw1 lh-copy">Christopher Sellers, Lindsey Dillon, Jennifer Liss Ohayon, Nick Shapiro, Marianne Sullivan, Chris Amoss, Stephen Bocking, Phil Brown, Vanessa De la Rosa, Jill Harrison, Sara Johns, Katherine Kulik, Rebecca Lave, Michelle Murphy, Liza Piper, Lauren Richter, Sara Wylie</p>
+              <p id="contrib" class="f5-l f7-m f7-ns fw1 lh-copy">{{ page.author }}</p>
             </div>
         </div>
     </header>

--- a/mustafa-ali-interview.html
+++ b/mustafa-ali-interview.html
@@ -1,7 +1,8 @@
 ---
 layout: default
+section: "2"
 title: "Interview With Mustafa Ali"
-description: "Former head of the EPA Office of Environmental Justice"
+subtitle: "Former head of the EPA Office of Environmental Justice"
 author: "Lindsey Dillon"
 og-image: "mustafa.jpg"
 permalink: /mustafa-ali-interview/
@@ -15,11 +16,11 @@ redirect_from:
         <div id="bg2a" class="chbg"></div>
         <div id="inner-wrapper">
             <div id="heds">
-                <h2 class="f3 ttu tl">Part 2</h2>
-                <h1 class="f-6-l f4-m f4-ns ttu tl">INTERVIEW WITH MUSTAFA ALI</h1>
-                <h2 class="f3 fw3 ttu tl pv2">Former head of the EPA Office of Environmental Justice</h2>
+                <h2 class="f3 ttu tl">Part {{ page.section }}</h2>
+                <h1 class="f-6-l f4-m f4-ns ttu tl">{{ page.title }}</h1>
+                <h2 class="f3 fw3 ttu tl pv2">{{ page.subtitle }}</h2>
             </div>
-            <p id="contrib"class="f5-l f7-m f7-ns fw1 lh-copy">Conducted by Lindsey Dillon</p>
+            <p id="contrib"class="f5-l f7-m f7-ns fw1 lh-copy">Conducted by {{ page.author }}</p>
         </div>
     </header>
 
@@ -27,7 +28,7 @@ redirect_from:
         <a href="/index.html" title="Home" class="">
             <img id="nav-logo" src="/assets/edgi-logo-b.png">
         </a>
-        <div id="nav-txt" class="di"><h3 class="f5 ttu tl mb0 di">Part 2</h3><h3 class="f5 fw3 ttu tl mb0 di"> | INTERVIEW WITH MUSTAFA ALI</h3></div>
+        <div id="nav-txt" class="di"><h3 class="f5 ttu tl mb0 di">Part {{ page.section }}</h3><h3 class="f5 fw3 ttu tl mb0 di"> | {{ page.title }}</h3></div>
     </div>
     <main class="flex">
         <div class="left-sidebar">

--- a/mustafa-ali-interview.html
+++ b/mustafa-ali-interview.html
@@ -24,12 +24,9 @@ redirect_from:
         </div>
     </header>
 
-    <div id="nav" class="w-100 pv1">
-        <a href="/index.html" title="Home" class="">
-            <img id="nav-logo" src="/assets/edgi-logo-b.png">
-        </a>
-        <div id="nav-txt" class="di"><h3 class="f5 ttu tl mb0 di">Part {{ page.section }}</h3><h3 class="f5 fw3 ttu tl mb0 di"> | {{ page.title }}</h3></div>
-    </div>
+    <!--NAVIGATION TOP-->
+    {% include nav.html %}
+
     <main class="flex">
         <div class="left-sidebar">
             <div class="back-to-article dib mh3">

--- a/pursuing-toxic-agenda-data.html
+++ b/pursuing-toxic-agenda-data.html
@@ -1,6 +1,8 @@
 ---
 layout: default
-title: "Part 2 - Data Methods"
+section: "2"
+title: "Data Methods"
+subtitle: "Pursuing a Toxic Agenda: Environmental Injustice in the Early Trump Administration"
 description: "Notes on Data Used in Figures"
 author: "Britt S. Paris, Shaquilla Singh, Sara Wylie"
 og-image: "ch2-cover.jpg"
@@ -14,9 +16,9 @@ redirect_from:
         <div id="bg2" class="chbg"></div>
         <div id="inner-wrapper">
             <div id="heds">
-                <h2 class="f3 ttu tl">Part 2</h2>
-                <h1 class="f-6-l f4-m f4-ns ttu tl">Data Methods</h1>
-                <h2 class="f3 fw3 ttu tl pv2">Notes on Data Used in Figures in PURSUING A TOXIC AGENDA: Environmental Injustice in the Early Trump Administration</h2>
+                <h2 class="f3 ttu tl">Part {{ page.section }}</h2>
+                <h1 class="f-6-l f4-m f4-ns ttu tl">{{ page.title }}</h1>
+                <h2 class="f3 fw3 ttu tl pv2">{{ page.description }} in {{ page.subtitle }}</h2>
             </div>
             <div><p id="contrib"class="f5-l f7-m f7-ns fw1 lh-copy">{{ page.author }}</p></div>
         </div>

--- a/pursuing-toxic-agenda-data.html
+++ b/pursuing-toxic-agenda-data.html
@@ -23,12 +23,10 @@ redirect_from:
             <div><p id="contrib"class="f5-l f7-m f7-ns fw1 lh-copy">{{ page.author }}</p></div>
         </div>
     </header>
-    <div id="nav" class="w-100 pv1">
-        <a href="/index.html" title="Home" class="">
-            <img id="nav-logo" src="/assets/edgi-logo-b.png">
-        </a>
-        <div id="nav-txt" class="di"><h3 class="f5 ttu tl mb0 di">Part 2</h3><h3 class="f5 fw3 ttu tl mb0 di"> | Data Methods</h3></div>
-    </div>
+
+    <!--NAVIGATION TOP-->
+    {% include nav.html %}
+
     <main class="flex">
         <div class="left-sidebar">
             <div class="back-to-article dib mh3">

--- a/pursuing-toxic-agenda-peer-reviews.html
+++ b/pursuing-toxic-agenda-peer-reviews.html
@@ -23,12 +23,9 @@ redirect_from:
             <div><p id="contrib" class="f5-l f7-m f7-ns fw1 lh-copy">{{ page.author }}</p></div>
         </div>
     </header>
-    <div id="nav" class="w-100 pv1">
-        <a href="/index.html" title="Home" class="">
-            <img id="nav-logo" src="/assets/edgi-logo-b.png">
-        </a>
-        <div id="nav-txt" class="di"><h3 class="f5 ttu tl mb0 di">Part 2</h3><h3 class="f5 fw3 ttu tl mb0 di"> | Peer Reviews</h3></div>
-    </div>
+    
+    <!--NAVIGATION TOP-->
+    {% include nav.html %}
 
     <main class="flex">
         <div class="left-sidebar">

--- a/pursuing-toxic-agenda-peer-reviews.html
+++ b/pursuing-toxic-agenda-peer-reviews.html
@@ -1,7 +1,8 @@
 ---
 layout: default
-title: "Part II Peer Reviews"
-description: "Pursuing a Toxic Agenda: Environmental Injustice in the Early Trump Administration"
+section: "2"
+title: "Peer Reviews"
+subtitle: "Pursuing a Toxic Agenda: Environmental Injustice in the Early Trump Administration"
 author: "Dr. Jill Harrison, Dr. Ellen Kohl"
 og-image: "ch2-cover.jpg"
 permalink: /pursuing-toxic-agenda-peer-reviews/
@@ -15,11 +16,11 @@ redirect_from:
         <div id="bg2" class="chbg"></div>
         <div id="inner-wrapper">
             <div id="heds">
-                <h2 class="f3 ttu tl">Part 2</h2>
-                <h1 class="f-6-l f4-m f4-ns ttu tl">Peer Reviews</h1>
-                <h2 class="f3 fw3 ttu tl pv2">Pursuing a Toxic Agenda: Environmental Injustice in the Early Trump Administration</h2>
+                <h2 class="f3 ttu tl">Part {{ page.section }}</h2>
+                <h1 class="f-6-l f4-m f4-ns ttu tl">{{ page.title }}</h1>
+                <h2 class="f3 fw3 ttu tl pv2">{{ page.subtitle }}</h2>
             </div>
-            <div><p id="contrib"class="f5-l f7-m f7-ns fw1 lh-copy">Dr. Jill Harrison, Dr. Ellen Kohl</p></div>
+            <div><p id="contrib" class="f5-l f7-m f7-ns fw1 lh-copy">{{ page.author }}</p></div>
         </div>
     </header>
     <div id="nav" class="w-100 pv1">

--- a/pursuing-toxic-agenda.html
+++ b/pursuing-toxic-agenda.html
@@ -24,12 +24,9 @@ redirect_from:
             <div><p id="contrib" class="f5-l f7-m f7-ns fw1 lh-copy">{{ page.author }}</p></div>
         </div>
     </header>
-    <div id="nav" class="w-100 pv1">
-        <a href="/index.html" title="Home" class="">
-            <img id="nav-logo" src="/assets/edgi-logo-b.png">
-        </a>
-        <div id="nav-txt" class="di"><h3 class="f5 ttu tl mb0 di">Part 2</h3><h3 class="f5 fw3 ttu tl mb0 di"> | Pursuing a Toxic Agenda</h3></div>
-    </div>
+
+    <!--NAVIGATION TOP-->
+    {% include nav.html %}
 
     <main class="flex">
         <div class="left-sidebar">

--- a/pursuing-toxic-agenda.html
+++ b/pursuing-toxic-agenda.html
@@ -1,7 +1,8 @@
 ---
 layout: default
-title: "Part 2 - Pursuing a Toxic Agenda"
-description: "Environmental Injustice in the Early Trump Administration"
+section: "2"
+title: "Pursuing a Toxic Agenda"
+subtitle: "Environmental Injustice in the Early Trump Administration"
 author: "Britt S. Paris, Lindsey Dillon, Jennifer Pierre, Irene V. Pasquetto, Emily Marquez, Sara Wylie, Michelle Murphy, Phil Brown, Rebecca Lave, Chris Sellers, Becky Mansfield, Leif Fredrickson, Nicholas Shapiro, EDGI"
 og-image: "ch2-cover.jpg"
 permalink: /pursuing-toxic-agenda/
@@ -16,11 +17,11 @@ redirect_from:
         <div id="bg2" class="chbg"></div>
         <div id="inner-wrapper">
             <div id="heds">
-                <h2 class="f3 ttu tl">Part 2</h2>
-                <h1 class="f-6-l f4-m f4-ns ttu tl">PURSUING A TOXIC AGENDA</h1>
-                <h2 class="f3 fw3 ttu tl pv2">Environmental Injustice in the Early Trump Administration</h2>
+                <h2 class="f3 ttu tl">Part {{ page.section }}</h2>
+                <h1 class="f-6-l f4-m f4-ns ttu tl">{{ page.title }}</h1>
+                <h2 class="f3 fw3 ttu tl pv2">{{ page.subtitle }}</h2>
             </div>
-            <div><p id="contrib" class="f5-l f7-m f7-ns fw1 lh-copy">Britt S. Paris, Lindsey Dillon, Jennifer Pierre, Irene V. Pasquetto, Emily Marquez, Sara Wylie, Michelle Murphy, Phil Brown, Rebecca Lave, Chris Sellers, Becky Mansfield, Leif Fredrickson, Nicholas Shapiro, EDGI</p></div>
+            <div><p id="contrib" class="f5-l f7-m f7-ns fw1 lh-copy">{{ page.author }}</p></div>
         </div>
     </header>
     <div id="nav" class="w-100 pv1">


### PR DESCRIPTION
There were a lot of inline changes between #67 and #92, better to just re-do on this one and close the previous PR, as this has been extensively reviewed prior, I'm going to do a quick merge for the basics once testing as we have the time crunch of upcoming work.

From #67, this:
- [x] better, separate metadata in yaml variables
- [x] swap in variables for each page
- [x] pull out `nav` section to includes
>- [x] pull out `back-to-top` and `back-to-article` sections to includes (haven't implemented as this and the sidebar have changed in placement)

  