### PR TITLE
Expand allowed ruby versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source "https://rubygems.org"
-ruby '~> 2.3.3'
+ruby '> 2.3.3'
 
 # Hello! This is where you manage which Jekyll version is used to run.
 # When you want to use a different version, change it below, save the

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source "https://rubygems.org"
-ruby '> 2.3.3'
+ruby '~> 2.3'
 
 # Hello! This is where you manage which Jekyll version is used to run.
 # When you want to use a different version, change it below, save the


### PR DESCRIPTION
In response to #99 (okay, okay, my own question....)I've searched around and done some testing.. from my probably limited research I think there is no reason why we can't have it as `ruby '> 2.3.3'`
