### PR TITLE
Upgrade rack to 2.1.4 to fix security error

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,7 +48,7 @@ GEM
       forwardable-extended (~> 2.6)
     public_suffix (3.0.3)
     puma (3.12.4)
-    rack (1.6.13)
+    rack (2.1.4)
     rack-jekyll (0.5.0)
       jekyll (>= 1.3)
       listen (>= 1.3)


### PR DESCRIPTION
I don't know Ruby on Rails well enough to test this change deeper, so just updated `rack` to the minimum version to get rid of the security warning. Re-built the site using `jekyll` and things look fine. Not sure how `rack` is actually used by the site itself (don't think it is because it's static), so if anybody has input that would be great!