### PR TITLE
Upgrade to Bundler 2.4.22

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,4 +73,4 @@ RUBY VERSION
    ruby 2.7.8p225
 
 BUNDLED WITH
-   1.17.2
+   2.4.22


### PR DESCRIPTION
This is the latest version of Bundler that still supports Ruby 2.x. The goal here is to allow Dependabot to work again.